### PR TITLE
Use implementation command for dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
Currently, when compiling a project for Android, the following warning message pops up in the console:

```
> Configure project :react-native-sound-player 
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

This pull request solves just that by replacing the deprecated `compile` command with the new `implementation` command.