### PR TITLE
Add loading finished event

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -53,6 +53,11 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
       this.mediaPlayer.setDataSource(getCurrentActivity(), uri);
       this.mediaPlayer.prepare();
     }
+
+    WritableMap params = Arguments.createMap();
+    params.putBoolean("success", true);
+    sendEvent(getReactApplicationContext(), "FinishedLoading", params);
+
     this.mediaPlayer.start();
   }
 
@@ -76,6 +81,11 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
       this.mediaPlayer.setDataSource(getCurrentActivity(), uri);
       this.mediaPlayer.prepare();
     }
+
+    WritableMap params = Arguments.createMap();
+    params.putBoolean("success", true);
+    sendEvent(getReactApplicationContext(), "FinishedLoading", params);
+
     this.mediaPlayer.start();
   }
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ module.exports = {
   },
 
   onFinishedPlaying: (callback: (success: boolean) => any) => {
+    if (_finishedPlayingListener) {
+      _finishedPlayingListener.remove();
+      _finishedPlayingListener = undefined;
+    }
+
     _finishedPlayingListener = _soundPlayerEmitter.addListener(
       "FinishedPlaying",
       callback
@@ -27,6 +32,11 @@ module.exports = {
   },
 
   onFinishedLoading: (callback: (success: boolean) => any) => {
+    if (_finishedLoadingListener) {
+      _finishedLoadingListener.remove();
+      _finishedLoadingListener = undefined;
+    }
+
     _finishedLoadingListener = _soundPlayerEmitter.addListener(
       "FinishedLoading",
       callback
@@ -48,7 +58,14 @@ module.exports = {
   getInfo: async () => RNSoundPlayer.getInfo(),
 
   unmount: () => {
-    _finishedPlayingListener && _finishedPlayingListener.remove();
-    _finishedLoadingListener && _finishedLoadingListener.remove();
+    if (_finishedPlayingListener) {
+      _finishedPlayingListener.remove();
+      _finishedPlayingListener = undefined;
+    }
+
+    if (_finishedLoadingListener) {
+      _finishedLoadingListener.remove();
+      _finishedLoadingListener = undefined;
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,71 +1,71 @@
 /**
  * @flow
  */
-"use strict";
+'use strict'
 
-import { NativeModules, NativeEventEmitter } from "react-native";
-const { RNSoundPlayer } = NativeModules;
+import { NativeModules, NativeEventEmitter } from 'react-native'
+const { RNSoundPlayer } = NativeModules
 
-const _soundPlayerEmitter = new NativeEventEmitter(RNSoundPlayer);
-let _finishedPlayingListener = null;
-let _finishedLoadingListener = null;
+const _soundPlayerEmitter = new NativeEventEmitter(RNSoundPlayer)
+let _finishedPlayingListener = null
+let _finishedLoadingListener = null
 
 module.exports = {
   playSoundFile: (name: string, type: string) => {
-    RNSoundPlayer.playSoundFile(name, type);
+    RNSoundPlayer.playSoundFile(name, type)
   },
 
   playUrl: (url: string) => {
-    RNSoundPlayer.playUrl(url);
+    RNSoundPlayer.playUrl(url)
   },
 
   onFinishedPlaying: (callback: (success: boolean) => any) => {
     if (_finishedPlayingListener) {
-      _finishedPlayingListener.remove();
-      _finishedPlayingListener = undefined;
+      _finishedPlayingListener.remove()
+      _finishedPlayingListener = undefined
     }
 
     _finishedPlayingListener = _soundPlayerEmitter.addListener(
-      "FinishedPlaying",
+      'FinishedPlaying',
       callback
-    );
+    )
   },
 
   onFinishedLoading: (callback: (success: boolean) => any) => {
     if (_finishedLoadingListener) {
-      _finishedLoadingListener.remove();
-      _finishedLoadingListener = undefined;
+      _finishedLoadingListener.remove()
+      _finishedLoadingListener = undefined
     }
 
     _finishedLoadingListener = _soundPlayerEmitter.addListener(
-      "FinishedLoading",
+      'FinishedLoading',
       callback
-    );
+    )
   },
 
   pause: () => {
-    RNSoundPlayer.pause();
+    RNSoundPlayer.pause()
   },
 
   resume: () => {
-    RNSoundPlayer.resume();
+    RNSoundPlayer.resume()
   },
 
   stop: () => {
-    RNSoundPlayer.stop();
+    RNSoundPlayer.stop()
   },
 
   getInfo: async () => RNSoundPlayer.getInfo(),
 
   unmount: () => {
     if (_finishedPlayingListener) {
-      _finishedPlayingListener.remove();
-      _finishedPlayingListener = undefined;
+      _finishedPlayingListener.remove()
+      _finishedPlayingListener = undefined
     }
 
     if (_finishedLoadingListener) {
-      _finishedLoadingListener.remove();
-      _finishedLoadingListener = undefined;
+      _finishedLoadingListener.remove()
+      _finishedLoadingListener = undefined
     }
   }
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,45 +1,54 @@
 /**
  * @flow
  */
-'use strict'
+"use strict";
 
-import { NativeModules, NativeEventEmitter } from 'react-native'
-const { RNSoundPlayer } = NativeModules
+import { NativeModules, NativeEventEmitter } from "react-native";
+const { RNSoundPlayer } = NativeModules;
 
-const _soundPlayerEmitter = new NativeEventEmitter(RNSoundPlayer)
-let _finishedPlayingListener = null
+const _soundPlayerEmitter = new NativeEventEmitter(RNSoundPlayer);
+let _finishedPlayingListener = null;
+let _finishedLoadingListener = null;
 
 module.exports = {
   playSoundFile: (name: string, type: string) => {
-    RNSoundPlayer.playSoundFile(name, type)
+    RNSoundPlayer.playSoundFile(name, type);
   },
 
   playUrl: (url: string) => {
-    RNSoundPlayer.playUrl(url)
+    RNSoundPlayer.playUrl(url);
   },
 
   onFinishedPlaying: (callback: (success: boolean) => any) => {
     _finishedPlayingListener = _soundPlayerEmitter.addListener(
-      'FinishedPlaying',
+      "FinishedPlaying",
       callback
-    )
+    );
+  },
+
+  onFinishedLoading: (callback: (success: boolean) => any) => {
+    _finishedLoadingListener = _soundPlayerEmitter.addListener(
+      "FinishedLoading",
+      callback
+    );
   },
 
   pause: () => {
-    RNSoundPlayer.pause()
+    RNSoundPlayer.pause();
   },
 
   resume: () => {
-    RNSoundPlayer.resume()
+    RNSoundPlayer.resume();
   },
 
   stop: () => {
-    RNSoundPlayer.stop()
+    RNSoundPlayer.stop();
   },
 
   getInfo: async () => RNSoundPlayer.getInfo(),
 
   unmount: () => {
-    _finishedPlayingListener && _finishedPlayingListener.remove()
+    _finishedPlayingListener && _finishedPlayingListener.remove();
+    _finishedLoadingListener && _finishedLoadingListener.remove();
   }
-}
+};

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -12,6 +12,8 @@ RCT_EXPORT_METHOD(playUrl:(NSString *)url) {
     NSURL *soundURL = [NSURL URLWithString:url];
     self.avPlayer = [[AVPlayer alloc] initWithURL:soundURL];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidFinishPlaying:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
+
+    [self sendEventWithName:@"FinishedLoading" body:@{@"success": [NSNumber numberWithBool:true]}];
     [self.avPlayer play];
 }
 
@@ -22,11 +24,13 @@ RCT_EXPORT_METHOD(playSoundFile:(NSString *)name ofType:(NSString *)type) {
     [self.player setDelegate:self];
     [self.player setNumberOfLoops:0];
     [self.player prepareToPlay];
+
+    [self sendEventWithName:@"FinishedLoading" body:@{@"success": [NSNumber numberWithBool:true]}];
     [self.player play];
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"FinishedPlaying"];
+    return @[@"FinishedPlaying", @"FinishedLoading"];
 }
 
 RCT_EXPORT_METHOD(pause) {


### PR DESCRIPTION
This PR includes some fixes for multiple `unmount()` calls, and an event which triggers when the file is finished loading. It should address this issue: https://github.com/johnsonsu/react-native-sound-player/issues/28

The commit history isn't great, but I'm submitting this early to see whether or not you approve of the implementation, before I go through the hassle of cleaning up the commit history and reverting style-only changes my editor inadvertently made to `index.js`...

While I have your attention: thank you for making this. I have found it useful, and am about to submit an app to both stores which includes this library.