### PR TITLE
Add documents playback

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -119,20 +119,7 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
       if (soundResID > 0) {
         this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), soundResID);
       } else {
-        String folder = getReactApplicationContext().getFilesDir().getAbsolutePath();
-        String file = name + "." + type;
-
-        // http://blog.weston-fl.com/android-mediaplayer-prepare-throws-status0x1-error1-2147483648
-        // this helps avoid a common error state when mounting the file
-        File ref = new File(folder + "/" + file);
-
-        if (ref.exists()) {
-          ref.setReadable(true, false);
-        }
-
-        Uri uri = Uri.parse("file://" + folder + "/" + file);
-
-        this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), uri);
+        this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), this.getUriFromFile(name, type));
       }
 
       this.mediaPlayer.setOnCompletionListener(
@@ -146,24 +133,12 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
       });
     } else {
       Uri uri;
-
       int soundResID = getReactApplicationContext().getResources().getIdentifier(name, "raw", getReactApplicationContext().getPackageName());
 
       if (soundResID > 0) {
         uri = Uri.parse("android.resource://" + getReactApplicationContext().getPackageName() + "/raw/" + name);
       } else {
-        String folder = getReactApplicationContext().getFilesDir().getAbsolutePath();
-        String file = name + "." + type;
-
-        // http://blog.weston-fl.com/android-mediaplayer-prepare-throws-status0x1-error1-2147483648
-        // this helps avoid a common error state when mounting the file
-        File ref = new File(folder + "/" + file);
-
-        if (ref.exists()) {
-          ref.setReadable(true, false);
-        }
-
-        uri = Uri.parse("file://" + folder + "/" + file);
+        uri = this.getUriFromFile(name, type);
       }
 
       this.mediaPlayer.reset();
@@ -174,5 +149,20 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
     WritableMap params = Arguments.createMap();
     params.putBoolean("success", true);
     sendEvent(getReactApplicationContext(), EVENT_FINISHED_LOADING, params);
+  }
+
+  private Uri getUriFromFile(String name, String type) {
+    String folder = getReactApplicationContext().getFilesDir().getAbsolutePath();
+    String file = name + "." + type;
+
+    // http://blog.weston-fl.com/android-mediaplayer-prepare-throws-status0x1-error1-2147483648
+    // this helps avoid a common error state when mounting the file
+    File ref = new File(folder + "/" + file);
+
+    if (ref.exists()) {
+      ref.setReadable(true, false);
+    }
+
+    return Uri.parse("file://" + folder + "/" + file);
   }
 }

--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -3,6 +3,7 @@ package com.johnsonsu.rnsoundplayer;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.net.Uri;
+import java.io.File;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -114,7 +115,26 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
   private void mountSoundFile(String name, String type) throws IOException {
     if (this.mediaPlayer == null) {
       int soundResID = getReactApplicationContext().getResources().getIdentifier(name, "raw", getReactApplicationContext().getPackageName());
-      this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), soundResID);
+
+      if (soundResID > 0) {
+        this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), soundResID);
+      } else {
+        String folder = getReactApplicationContext().getFilesDir().getAbsolutePath();
+        String file = name + "." + type;
+
+        // http://blog.weston-fl.com/android-mediaplayer-prepare-throws-status0x1-error1-2147483648
+        // this helps avoid a common error state when mounting the file
+        File ref = new File(folder + "/" + file);
+
+        if (ref.exists()) {
+          ref.setReadable(true, false);
+        }
+
+        Uri uri = Uri.parse("file://" + folder + "/" + file);
+
+        this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), uri);
+      }
+
       this.mediaPlayer.setOnCompletionListener(
         new OnCompletionListener() {
           @Override
@@ -125,11 +145,32 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
           }
       });
     } else {
-      Uri uri = Uri.parse("android.resource://" + getReactApplicationContext().getPackageName() + "/raw/" + name);
+      Uri uri;
+
+      int soundResID = getReactApplicationContext().getResources().getIdentifier(name, "raw", getReactApplicationContext().getPackageName());
+
+      if (soundResID > 0) {
+        uri = Uri.parse("android.resource://" + getReactApplicationContext().getPackageName() + "/raw/" + name);
+      } else {
+        String folder = getReactApplicationContext().getFilesDir().getAbsolutePath();
+        String file = name + "." + type;
+
+        // http://blog.weston-fl.com/android-mediaplayer-prepare-throws-status0x1-error1-2147483648
+        // this helps avoid a common error state when mounting the file
+        File ref = new File(folder + "/" + file);
+
+        if (ref.exists()) {
+          ref.setReadable(true, false);
+        }
+
+        uri = Uri.parse("file://" + folder + "/" + file);
+      }
+
       this.mediaPlayer.reset();
       this.mediaPlayer.setDataSource(getCurrentActivity(), uri);
       this.mediaPlayer.prepare();
     }
+
     WritableMap params = Arguments.createMap();
     params.putBoolean("success", true);
     sendEvent(getReactApplicationContext(), EVENT_FINISHED_LOADING, params);

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -99,7 +99,16 @@ RCT_REMAP_METHOD(getInfo,
     if (self.avPlayer) {
         self.avPlayer = nil;
     }
+
     NSString *soundFilePath = [[NSBundle mainBundle] pathForResource:name ofType:type];
+
+    if (soundFilePath == nil) {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,NSUserDomainMask, YES);
+        NSString *documentsDirectory = [paths objectAtIndex:0];
+
+        soundFilePath = [NSString stringWithFormat:@"%@.%@", [documentsDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"%@",name]], type];
+    }
+
     NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];
     self.player = [[AVAudioPlayer alloc] initWithContentsOfURL:soundFileURL error:nil];
     [self.player setDelegate:self];


### PR DESCRIPTION
This adds a fallback for bundled sound files, to use sound files in the "documents" directory. It can be used in conjunction with libraries like https://github.com/EkoLabs/react-native-background-downloader. It should resolve issues like https://github.com/johnsonsu/react-native-sound-player/issues/10.