### PR TITLE
Fix RN >= 0.60 auto linking for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Play audio files, stream audio from URL, using ReactNative.
 
 ### 2. Link
 
+For RN >= 0.60 you can skip this step.
+
 ```
     react-native link react-native-sound-player
 ```

--- a/RNSoundPlayer.podspec
+++ b/RNSoundPlayer.podspec
@@ -1,0 +1,18 @@
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+
+  s.name           = "RNSoundPlayer"
+  s.version        = package['version']
+  s.summary        = package["description"]
+  s.homepage       = "https://github.com/johnsonsu/react-native-sound-player"
+  s.license        = package["license"]
+  s.author         = { "Johnson Su" => "johnsonsu@johnsonsu.com" }
+  s.platforms      = { :ios => "9.0", :tvos => "9.0" }
+  s.source         = { :git => "https://github.com/johnsonsu/react-native-sound-player.git", :tag => s.version }
+  s.source_files   = 'ios/**/*.{h,m}'
+  s.preserve_paths = "package.json", "LICENSE"
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
This should fix the auto link in ios.

**NOTE:**
From now on, all version releases should have a tag, or the pod installed will default to master.
tag pattern is based on your current tags -> `x.x.x`