### PR TITLE
exports using `export default`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const _soundPlayerEmitter = new NativeEventEmitter(RNSoundPlayer)
 let _finishedPlayingListener = null
 let _finishedLoadingListener = null
 
-module.exports = {
+export default {
 
   playSoundFile: (name: string, type: string) => {
     RNSoundPlayer.playSoundFile(name, type)


### PR DESCRIPTION
I'm using expo and running on the web interface for development and webpack is complaining about mixing imports and exports. Exact error is:
```
Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'
```

Webpack issue [here](https://github.com/webpack/webpack/issues/4039#issuecomment-273804003) says not to mix imports and module.exports