### PR TITLE
Change prepare into prepareAsync

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -2,6 +2,7 @@ package com.johnsonsu.rnsoundplayer;
 
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
+import android.media.MediaPlayer.OnPreparedListener;
 import android.net.Uri;
 import java.io.File;
 
@@ -176,7 +177,7 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
     return Uri.parse("file://" + folder + "/" + file);
   }
 
-  private void prepareUrl(String url) throws IOException {
+  private void prepareUrl(final String url) throws IOException {
     if (this.mediaPlayer == null) {
       Uri uri = Uri.parse(url);
       this.mediaPlayer = MediaPlayer.create(getCurrentActivity(), uri);
@@ -189,18 +190,25 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
             sendEvent(getReactApplicationContext(), EVENT_FINISHED_PLAYING, params);
           }
       });
+      this.mediaPlayer.setOnPreparedListener(
+        new OnPreparedListener() {
+          @Override
+          public void onPrepared(MediaPlayer mediaPlayer) {
+            WritableMap onFinishedLoadingURLParams = Arguments.createMap();
+            onFinishedLoadingURLParams.putBoolean("success", true);
+            onFinishedLoadingURLParams.putString("url", url);
+            sendEvent(getReactApplicationContext(), EVENT_FINISHED_LOADING_URL, onFinishedLoadingURLParams);
+          }
+        }
+      );
     } else {
       Uri uri = Uri.parse(url);
       this.mediaPlayer.reset();
       this.mediaPlayer.setDataSource(getCurrentActivity(), uri);
-      this.mediaPlayer.prepare();
+      this.mediaPlayer.prepareAsync();
     }
     WritableMap params = Arguments.createMap();
     params.putBoolean("success", true);
     sendEvent(getReactApplicationContext(), EVENT_FINISHED_LOADING, params);
-    WritableMap onFinshedLoadingURLParams = Arguments.createMap();
-    onFinshedLoadingURLParams.putBoolean("success", true);
-    onFinshedLoadingURLParams.putString("url", url);
-    sendEvent(getReactApplicationContext(), EVENT_FINISHED_LOADING_URL, onFinshedLoadingURLParams);
   }
 }


### PR DESCRIPTION
Hello !

This is my first pull request, I found a bug which appears in some dark cases...
I tried to play a sound after a WakeLock, and had an inconsistent value when I called getInfo, and no sound played.

After hours and days of research to understand how MediaPlayer works, I finally understand that audio was tried to be played with a bad MediaPlayer state (prepare was not finished).

This pull request fix this problem with prepareAsync(). I just called it instead of prepare(), and send the event "finishedLoading" inside onPreparedListener.
It fix my issue, and produce no regression the fix is simple, and I hope it will be accepted, because I don't want to use another module, this one works very well and is very simple !

Best regards
Florient