### PR TITLE
Force to play sound when the device use mute profile.

### DIFF
--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -140,6 +140,9 @@ RCT_REMAP_METHOD(getInfo,
     [self.player setDelegate:self];
     [self.player setNumberOfLoops:0];
     [self.player prepareToPlay];
+    [[AVAudioSession sharedInstance]
+            setCategory: AVAudioSessionCategoryPlayback
+            error: nil];
     [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:true]}];
     [self sendEventWithName:EVENT_FINISHED_LOADING_FILE body:@{@"success": [NSNumber numberWithBool:true], @"name": name, @"type": type}];
 }


### PR DESCRIPTION
Currently we can't play the sound when device using mute profile, hope can force to play sound even if device using mute profile. Or else you can add an option to enable play sound when device using mute profile. Thank you. 