### PR TITLE
fix multiple observers added after loading urls for multiple times

### DIFF
--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -152,10 +152,13 @@ RCT_REMAP_METHOD(getInfo,
         self.player = nil;
     }
     NSURL *soundURL = [NSURL URLWithString:url];
+
+    if (!self.avPlayer) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidFinishPlaying:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
+    }
+
     self.avPlayer = [[AVPlayer alloc] initWithURL:soundURL];
     [self.player prepareToPlay];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidFinishPlaying:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
-
     [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:true]}];
     [self sendEventWithName:EVENT_FINISHED_LOADING_URL body: @{@"success": [NSNumber numberWithBool:true], @"url": url}];
 }


### PR DESCRIPTION
In iOS, multiple "FinishedPlaying" events are firing after loaded urls for multiple times. The PR is to make sure the observer is only added once.