### PR TITLE
Add ability to delay the start of a sound file by a number of seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ try {
 
 Play the sound file named `fileName` with file type `fileType`.
 
+
+### `playSoundFileWithDelay(fileName: string, fileType: string, delay: number)` - iOS Only
+
+Play the sound file named `fileName` with file type `fileType` after a a delay of `delay` in *seconds* from the current device time.
+
 ### `loadSoundFile(fileName: string, fileType: string)`
 
 Load the sound file named `fileName` with file type `fileType`, without playing it.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ export default {
   playSoundFile: (name: string, type: string) => {
     RNSoundPlayer.playSoundFile(name, type)
   },
+  
+  playSoundFileWithDelay: (name: string, type: string, delay: number) => {
+    RNSoundPlayer.playSoundFileWithDelay(name, type, delay)
+  },
 
   loadSoundFile: (name: string, type: string) => {
     RNSoundPlayer.loadSoundFile(name, type)

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -28,6 +28,11 @@ RCT_EXPORT_METHOD(playSoundFile:(NSString *)name ofType:(NSString *)type) {
     [self.player play];
 }
 
+RCT_EXPORT_METHOD(playSoundFileWithDelay:(NSString *)name ofType:(NSString *)type delay:(double)delay) {
+    [self mountSoundFile:name ofType:type];
+    [self.player playAtTime:(self.player.deviceCurrentTime + delay)];
+}
+
 RCT_EXPORT_METHOD(loadSoundFile:(NSString *)name ofType:(NSString *)type) {
     [self mountSoundFile:name ofType:type];
 }


### PR DESCRIPTION
Gives the ability to offset device play. 

*Note* if you want this to work while in the background after the standard resource allocation time for your application, Run in Background functionality must be enabled in XCode.