### PR TITLE
Add ability to mix audio on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Seek to `seconds` of the currently playing file.
 
 Only available on iOS. Overwrite default audio output to speaker, which forces `playUrl()` function to play from speaker.
 
+### `setMixAudio(on: boolean)`
+
+Only available on iOS. If you set this option, your audio will be mixed with audio playing in background apps, such as the Music app.
+
 ### `setVolume(volume: number)`
 
 Set the volume of the current player. This does not change the volume of the device.

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,8 @@ declare module "react-native-sound-player" {
     setVolume: (volume: number) => void;
     /** Only available on iOS. Overwrite default audio output to speaker, which forces playUrl() function to play from speaker. */
     setSpeaker: (on: boolean) => void;
+    /** Only available on iOS. If you set this option, your audio will be mixed with audio playing in background apps, such as the Music app. */
+    setMixAudio: (on: boolean) => void;
     /** IOS only. Set the number of loops. A negative value will loop indefinitely until the stop() command is called. */
     setNumberOfLoops: (loops: number) => void;
     /** Get the currentTime and duration of the currently mounted audio media. This function returns a promise which resolves to an Object containing currentTime and duration properties. */

--- a/index.js
+++ b/index.js
@@ -95,9 +95,17 @@ export default {
 
   setSpeaker: (on: boolean) => {
     if (Platform.OS === "android") {
-      console.log("setSpeaker is not implement on Android");
+      console.log("setSpeaker is not implemented on Android");
     } else {
       RNSoundPlayer.setSpeaker(on);
+    }
+  },
+
+  setMixAudio: (on: boolean) => {
+    if (Platform.OS === "android") {
+      console.log("setMixAudio is not implemented on Android");
+    } else {
+      RNSoundPlayer.setMixAudio(on);
     }
   },
 

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -89,6 +89,17 @@ RCT_EXPORT_METHOD(setSpeaker:(BOOL) on) {
     [session setActive:true error:nil];
 }
 
+RCT_EXPORT_METHOD(setMixAudio:(BOOL) on) {
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+
+    if (on) {
+        [session setCategory: AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+    } else {
+        [session setCategory: AVAudioSessionCategoryPlayback withOptions:0 error:nil];
+    }
+    [session setActive:true error:nil];
+}
+
 RCT_EXPORT_METHOD(setVolume:(float)volume) {
     if (self.player != nil) {
         [self.player setVolume: volume];


### PR DESCRIPTION
Adds an option, `setMixAudio`, which allows other music (e.g. Music app / Spotify / etc) to continue playing while RNSoundPlayer audio is playing. This should solve https://github.com/johnsonsu/react-native-sound-player/issues/72

Uses the `AVAudioSessionCategoryOptionMixWithOthers` option which can be set on the `AVAudioSessionCategoryPlayback` category (see [here](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionCategoriesandModes/AudioSessionCategoriesandModes.html#//apple_ref/doc/uid/TP40007875-CH10) and [here](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionmixwithothers)).