### PR TITLE
bug fix - playing new audio file on Android

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -209,7 +209,7 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
       Uri uri = Uri.parse(url);
       this.mediaPlayer.reset();
       this.mediaPlayer.setDataSource(getCurrentActivity(), uri);
-      this.mediaPlayer.prepareAsync();
+      this.mediaPlayer.prepare();
     }
     WritableMap params = Arguments.createMap();
     params.putBoolean("success", true);


### PR DESCRIPTION
A bug in Android version prevents us to play a new audio from URL or to replay the existing URL. So by changing this.mediaPlayer.prepareAsync() to this.mediaPlayer.prepare() on RNSoundPlayerModule.java this bug is now fixed. 