### PR TITLE
Add missing methods in android native module to prevent warning

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -136,6 +136,16 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule implements L
     promise.resolve(map);
   }
 
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
+
   private void sendEvent(ReactApplicationContext reactContext,
                        String eventName,
                        @Nullable WritableMap params) {


### PR DESCRIPTION
Native modules in Android that are used as a NativeEventEmitter
are expected to contain methods addListener and removeListeners ([docs]).
In the case of this module, they don't actually need to do anything, but
they should still be there to avoid warnings.

[docs]: https://reactnative.dev/docs/native-modules-android#sending-events-to-javascript