### PR TITLE
Fix error during assembleRelease with react-native@0.69.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
This resolves an error I'm getting when running `gradle assembleRelease` 

```
Execution failed for task ':react-native-sound-player:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:~/.gradle/caches/transforms-3/e6a7b0cb90c4290418ec2361cd5de7d3/transformed/core-1.7.0/res/values/values.xml:105:5-114:25: AAPT: error: resource android:attr/lStar not found.
```

