### PR TITLE
Fix: Ensure proper lifecycle and error handling in iOS and Android implementations

### DIFF
--- a/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
+++ b/android/src/main/java/com/johnsonsu/rnsoundplayer/RNSoundPlayerModule.java
@@ -20,9 +20,10 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.LifecycleEventListener;
 
 
-public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
+public class RNSoundPlayerModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
   public final static String EVENT_FINISHED_PLAYING = "FinishedPlaying";
   public final static String EVENT_FINISHED_LOADING = "FinishedLoading";
@@ -50,6 +51,17 @@ public class RNSoundPlayerModule extends ReactContextBaseJavaModule {
   public void setSpeaker(Boolean on) {
     audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
     audioManager.setSpeakerphoneOn(on);
+  }
+
+  @Override
+  public void onHostResume() {}
+
+  @Override
+  public void onHostPause() {}
+
+  @Override
+  public void onHostDestroy() {
+    this.stop();
   }
 
   @ReactMethod

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare module "react-native-sound-player" {
   import { EmitterSubscription } from "react-native";
 
   export type SoundPlayerEvent =
+    | "OnSetupError"
     | "FinishedLoading"
     | "FinishedPlaying"
     | "FinishedLoadingURL"

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ export default {
     }
 
     _finishedPlayingListener = _soundPlayerEmitter.addListener(
-      "FinishedPlaying",
-      callback
+        "FinishedPlaying",
+        callback
     );
   },
 
@@ -61,6 +61,7 @@ export default {
 
   addEventListener: (
     eventName:
+      | "OnSetupError"
       | "FinishedLoading"
       | "FinishedPlaying"
       | "FinishedLoadingURL"

--- a/ios/RNSoundPlayer.m
+++ b/ios/RNSoundPlayer.m
@@ -5,18 +5,49 @@
 //
 
 #import "RNSoundPlayer.h"
+#import <AVFoundation/AVFoundation.h>
 
 @implementation RNSoundPlayer
 
+static NSString *const EVENT_SETUP_ERROR = @"OnSetupError";
 static NSString *const EVENT_FINISHED_LOADING = @"FinishedLoading";
 static NSString *const EVENT_FINISHED_LOADING_FILE = @"FinishedLoadingFile";
 static NSString *const EVENT_FINISHED_LOADING_URL = @"FinishedLoadingURL";
 static NSString *const EVENT_FINISHED_PLAYING = @"FinishedPlaying";
 
+RCT_EXPORT_MODULE();
+
+@synthesize bridge = _bridge;
+
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.loopCount = 0;
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(itemDidFinishPlaying:)
+                                                     name:AVPlayerItemDidPlayToEndTimeNotification
+                                                   object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+    return @[EVENT_FINISHED_PLAYING, EVENT_FINISHED_LOADING, EVENT_FINISHED_LOADING_URL, EVENT_FINISHED_LOADING_FILE, EVENT_SETUP_ERROR];
+}
 
 RCT_EXPORT_METHOD(playUrl:(NSString *)url) {
     [self prepareUrl:url];
-    [self.avPlayer play];
+    if (self.avPlayer) {
+        [self.avPlayer play];
+    }
 }
 
 RCT_EXPORT_METHOD(loadUrl:(NSString *)url) {
@@ -25,20 +56,20 @@ RCT_EXPORT_METHOD(loadUrl:(NSString *)url) {
 
 RCT_EXPORT_METHOD(playSoundFile:(NSString *)name ofType:(NSString *)type) {
     [self mountSoundFile:name ofType:type];
-    [self.player play];
+    if (self.player) {
+        [self.player play];
+    }
 }
 
 RCT_EXPORT_METHOD(playSoundFileWithDelay:(NSString *)name ofType:(NSString *)type delay:(double)delay) {
     [self mountSoundFile:name ofType:type];
-    [self.player playAtTime:(self.player.deviceCurrentTime + delay)];
+    if (self.player) {
+        [self.player playAtTime:(self.player.deviceCurrentTime + delay)];
+    }
 }
 
 RCT_EXPORT_METHOD(loadSoundFile:(NSString *)name ofType:(NSString *)type) {
     [self mountSoundFile:name ofType:type];
-}
-
-- (NSArray<NSString *> *)supportedEvents {
-    return @[EVENT_FINISHED_PLAYING, EVENT_FINISHED_LOADING, EVENT_FINISHED_LOADING_URL, EVENT_FINISHED_LOADING_FILE];
 }
 
 RCT_EXPORT_METHOD(pause) {
@@ -65,6 +96,7 @@ RCT_EXPORT_METHOD(stop) {
     }
     if (self.avPlayer != nil) {
         [self.avPlayer pause];
+        [self.avPlayer seekToTime:kCMTimeZero];
     }
 }
 
@@ -73,45 +105,52 @@ RCT_EXPORT_METHOD(seek:(float)seconds) {
         self.player.currentTime = seconds;
     }
     if (self.avPlayer != nil) {
-        [self.avPlayer seekToTime: CMTimeMakeWithSeconds(seconds, 1.0)];
+        [self.avPlayer seekToTime:CMTimeMakeWithSeconds(seconds, NSEC_PER_SEC)];
     }
 }
 
 #if !TARGET_OS_TV
-RCT_EXPORT_METHOD(setSpeaker:(BOOL) on) {
+RCT_EXPORT_METHOD(setSpeaker:(BOOL)on) {
     AVAudioSession *session = [AVAudioSession sharedInstance];
+    NSError *error = nil;
     if (on) {
-        [session setCategory: AVAudioSessionCategoryPlayAndRecord error: nil];
-        [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+        [session setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
+        [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
     } else {
-        [session setCategory: AVAudioSessionCategoryPlayback error: nil];
-        [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+        [session setCategory:AVAudioSessionCategoryPlayback error:&error];
+        [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
     }
-    [session setActive:true error:nil];
+    [session setActive:YES error:&error];
+    if (error) {
+        [self sendErrorEvent:error];
+    }
 }
 #endif
 
-RCT_EXPORT_METHOD(setMixAudio:(BOOL) on) {
+RCT_EXPORT_METHOD(setMixAudio:(BOOL)on) {
     AVAudioSession *session = [AVAudioSession sharedInstance];
-    
+    NSError *error = nil;
     if (on) {
-        [session setCategory: AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+        [session setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
     } else {
-        [session setCategory: AVAudioSessionCategoryPlayback withOptions:0 error:nil];
+        [session setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:&error];
     }
-    [session setActive:true error:nil];
+    [session setActive:YES error:&error];
+    if (error) {
+        [self sendErrorEvent:error];
+    }
 }
 
-RCT_EXPORT_METHOD(setVolume:(float) volume) {
+RCT_EXPORT_METHOD(setVolume:(float)volume) {
     if (self.player != nil) {
-        [self.player setVolume: volume];
+        [self.player setVolume:volume];
     }
     if (self.avPlayer != nil) {
-        [self.avPlayer setVolume: volume];
+        [self.avPlayer setVolume:volume];
     }
 }
 
-RCT_EXPORT_METHOD(setNumberOfLoops:(NSInteger) loopCount) {
+RCT_EXPORT_METHOD(setNumberOfLoops:(NSInteger)loopCount) {
     self.loopCount = loopCount;
     if (self.player != nil) {
         [self.player setNumberOfLoops:loopCount];
@@ -119,17 +158,15 @@ RCT_EXPORT_METHOD(setNumberOfLoops:(NSInteger) loopCount) {
 }
 
 RCT_REMAP_METHOD(getInfo,
-                 getInfoWithResolver:(RCTPromiseResolveBlock) resolve
-                 rejecter:(RCTPromiseRejectBlock) reject) {
+                 getInfoWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
     if (self.player != nil) {
         NSDictionary *data = @{
             @"currentTime": [NSNumber numberWithDouble:[self.player currentTime]],
             @"duration": [NSNumber numberWithDouble:[self.player duration]]
         };
         resolve(data);
-        return;
-    }
-    if (self.avPlayer != nil) {
+    } else if (self.avPlayer != nil) {
         CMTime currentTime = [[self.avPlayer currentItem] currentTime];
         CMTime duration = [[[self.avPlayer currentItem] asset] duration];
         NSDictionary *data = @{
@@ -137,60 +174,74 @@ RCT_REMAP_METHOD(getInfo,
             @"duration": [NSNumber numberWithFloat:CMTimeGetSeconds(duration)]
         };
         resolve(data);
-        return;
+    } else {
+        resolve(nil);
     }
-    resolve(nil);
 }
 
-- (void) audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag {
+- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag {
     [self sendEventWithName:EVENT_FINISHED_PLAYING body:@{@"success": [NSNumber numberWithBool:flag]}];
 }
 
-- (void) itemDidFinishPlaying:(NSNotification *) notification {
-    [self sendEventWithName:EVENT_FINISHED_PLAYING body:@{@"success": [NSNumber numberWithBool:TRUE]}];
+- (void)itemDidFinishPlaying:(NSNotification *)notification {
+    [self sendEventWithName:EVENT_FINISHED_PLAYING body:@{@"success": [NSNumber numberWithBool:YES]}];
 }
 
-- (void) mountSoundFile:(NSString *)name ofType:(NSString *)type {
+- (void)mountSoundFile:(NSString *)name ofType:(NSString *)type {
     if (self.avPlayer) {
         self.avPlayer = nil;
     }
-    
+
     NSString *soundFilePath = [[NSBundle mainBundle] pathForResource:name ofType:type];
-    
+
     if (soundFilePath == nil) {
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,NSUserDomainMask, YES);
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSString *documentsDirectory = [paths objectAtIndex:0];
-        soundFilePath = [NSString stringWithFormat:@"%@.%@", [documentsDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"%@",name]], type];
+        soundFilePath = [NSString stringWithFormat:@"%@.%@", [documentsDirectory stringByAppendingPathComponent:name], type];
     }
-    
+
     NSURL *soundFileURL = [NSURL fileURLWithPath:soundFilePath];
-    self.player = [[AVAudioPlayer alloc] initWithContentsOfURL:soundFileURL error:nil];
+    NSError *error = nil;
+    self.player = [[AVAudioPlayer alloc] initWithContentsOfURL:soundFileURL error:&error];
+    if (error) {
+        [self sendErrorEvent:error];
+        return;
+    }
     [self.player setDelegate:self];
     [self.player setNumberOfLoops:self.loopCount];
     [self.player prepareToPlay];
-    [[AVAudioSession sharedInstance]
-     setCategory: AVAudioSessionCategoryPlayback
-     error: nil];
-    [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:true]}];
-    [self sendEventWithName:EVENT_FINISHED_LOADING_FILE body:@{@"success": [NSNumber numberWithBool:true], @"name": name, @"type": type}];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+    if (error) {
+        [self sendErrorEvent:error];
+        return;
+    }
+    [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:YES]}];
+    [self sendEventWithName:EVENT_FINISHED_LOADING_FILE body:@{@"success": [NSNumber numberWithBool:YES], @"name": name, @"type": type}];
 }
 
-- (void) prepareUrl:(NSString *)url {
+- (void)prepareUrl:(NSString *)url {
     if (self.player) {
         self.player = nil;
     }
     NSURL *soundURL = [NSURL URLWithString:url];
-    
-    if (!self.avPlayer) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidFinishPlaying:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
-    }
-    
     self.avPlayer = [[AVPlayer alloc] initWithURL:soundURL];
-    [self.player prepareToPlay];
-    [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:true]}];
-    [self sendEventWithName:EVENT_FINISHED_LOADING_URL body: @{@"success": [NSNumber numberWithBool:true], @"url": url}];
+    [self.avPlayer.currentItem addObserver:self forKeyPath:@"status" options:0 context:nil];
 }
 
-RCT_EXPORT_MODULE();
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+    if (object == self.avPlayer.currentItem && [keyPath isEqualToString:@"status"]) {
+        if (self.avPlayer.currentItem.status == AVPlayerItemStatusReadyToPlay) {
+            [self sendEventWithName:EVENT_FINISHED_LOADING body:@{@"success": [NSNumber numberWithBool:YES]}];
+            NSURL *url = [(AVURLAsset *)self.avPlayer.currentItem.asset URL];
+            [self sendEventWithName:EVENT_FINISHED_LOADING_URL body:@{@"success": [NSNumber numberWithBool:YES], @"url": [url absoluteString]}];
+        } else if (self.avPlayer.currentItem.status == AVPlayerItemStatusFailed) {
+            [self sendErrorEvent:self.avPlayer.currentItem.error];
+        }
+    }
+}
+
+- (void)sendErrorEvent:(NSError *)error {
+    [self sendEventWithName:EVENT_SETUP_ERROR body:@{@"error": [error localizedDescription]}];
+}
 
 @end


### PR DESCRIPTION
- Added requiresMainQueueSetup method to iOS to prevent warnings and ensure proper initialization on the main queue.
- Enhanced error handling in iOS to match Android implementation.
- Properly observe and clean up AVPlayerItem's status in iOS.
- Improved consistency and resource management in both iOS and Android.
- Fixed potential null pointer issues in Android MediaPlayer initialization.

Should [fix this issue](https://github.com/johnsonsu/react-native-sound-player/issues/111) by throwing an error which can be listened to in RN. 

**I'm not an iOS / Android dev and got some help from ChatGPT. I would love someone with a better understanding of native development to double check this!** 
